### PR TITLE
feat: UIViewController extension 추가

### DIFF
--- a/dnd-14th-1-iOS.xcodeproj/project.pbxproj
+++ b/dnd-14th-1-iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7C61D2FE2F210AAC005FAC3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D2F52F210AAC005FAC3A /* AppDelegate.swift */; };
 		7C61D2FF2F210AAC005FAC3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61D2F92F210AAC005FAC3A /* SceneDelegate.swift */; };
 		7C61D3012F210AAC005FAC3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7C61D2F62F210AAC005FAC3A /* Assets.xcassets */; };
+		7C8AABB42F437FBD0011E4CF /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8AABB32F437FBD0011E4CF /* UIViewController+.swift */; };
 		7C9582A42F3561DC004F8523 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582A32F3561DC004F8523 /* OnboardingViewController.swift */; };
 		7C9582A92F3562D0004F8523 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582A82F3562D0004F8523 /* LoginViewController.swift */; };
 		7C9582AE2F356608004F8523 /* CheckLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582AD2F356608004F8523 /* CheckLoginUseCase.swift */; };
@@ -103,6 +104,7 @@
 		7C61D2F62F210AAC005FAC3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7C61D2F82F210AAC005FAC3A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7C61D2F92F210AAC005FAC3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		7C8AABB32F437FBD0011E4CF /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		7C9582A32F3561DC004F8523 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		7C9582A82F3562D0004F8523 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7C9582AD2F356608004F8523 /* CheckLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginUseCase.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				00F482422F2DDB9D006FBD2A /* UITextField+.swift */,
 				00F481712F2DD571006FBD2A /* UIFont+.swift */,
 				7C2E31FB2F38DDA6006F08FE /* UIImage+.swift */,
+				7C8AABB32F437FBD0011E4CF /* UIViewController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -589,6 +592,7 @@
 				7CCB1E672F2DB72A00472669 /* MockRequest.swift in Sources */,
 				7C2E31FC2F38DDA6006F08FE /* UIImage+.swift in Sources */,
 				00113F2F2F43012700D4CC37 /* OnboardingCoordinator.swift in Sources */,
+				7C8AABB42F437FBD0011E4CF /* UIViewController+.swift in Sources */,
 				7C9582AE2F356608004F8523 /* CheckLoginUseCase.swift in Sources */,
 				00113F0D2F42FFA000D4CC37 /* UIColor+.swift in Sources */,
 				0027D9E62F4055E7000DE576 /* TabBarCoordinator.swift in Sources */,

--- a/dnd-14th-1-iOS/Global/Extension/UIViewController+.swift
+++ b/dnd-14th-1-iOS/Global/Extension/UIViewController+.swift
@@ -1,0 +1,20 @@
+//
+//  UIViewController+.swift
+//  dnd-14th-1-iOS
+//
+//  Created by 홍기정 on 2/17/26.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    func dismissKeyboardWhenTapAround() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/dnd-14th-1-iOS/Global/Extension/UIViewController+.swift
+++ b/dnd-14th-1-iOS/Global/Extension/UIViewController+.swift
@@ -11,6 +11,7 @@ extension UIViewController {
     
     func dismissKeyboardWhenTapAround() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGestureRecognizer.cancelsTouchesInView = false
         view.addGestureRecognizer(tapGestureRecognizer)
     }
     

--- a/dnd-14th-1-iOS/Presentation/LoginOnBoarding/OnboardingViewController.swift
+++ b/dnd-14th-1-iOS/Presentation/LoginOnBoarding/OnboardingViewController.swift
@@ -1,0 +1,151 @@
+//
+//  OnboardingViewController.swift
+//  dnd-14th-1-iOS
+//
+//  Created by 홍기정 on 2/6/26.
+//
+
+import UIKit
+import Combine
+import Then
+import SnapKit
+
+final class OnboardingViewController: BaseViewController {
+    
+    // MARK: - Properties
+    weak var delegate: OnboardingViewControllerDelegate?
+    
+    private var subscriptions: Set<AnyCancellable> = []
+    
+    private let items: [OnboardingItem] = [
+        OnboardingItem(
+            title: "프롬프트 입력",
+            description: "내가 쓰고 있는 프롬프트를\n진단받을 수 있어요",
+            image: UIImage.onboarding1
+        ),
+        OnboardingItem(
+            title: "프롬프트 체크",
+            description: "비효율적인 프롬프트를 입력하면\n빙하 상태가 변경돼요",
+            image: UIImage.onboarding2
+        ),
+        OnboardingItem(
+            title: "프롬프트 수정",
+            description: "불필요한 내용을 수정 받아\n빙하를 더 단단하게 만들어요",
+            image: UIImage.onboarding3
+        ),
+        OnboardingItem(
+            title: "뱃지 수집",
+            description: "올바른 프롬프트로 빙하를 지킨만큼\n뱃지를 가질 수 있어요",
+            image: UIImage.onboarding4
+        )
+    ]
+    
+    // MARK: - UI Components
+    private let onboardingPageControl = OnboardingPageControl()
+    
+    private lazy var onboardingCollectionView = OnboardingCollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewLayout()
+    ).then {
+        $0.isPagingEnabled = true
+        $0.showsHorizontalScrollIndicator = false
+        $0.isHidden = true
+        $0.backgroundColor = .white
+    }
+    
+    private let nextButton = UIButton().then {
+        $0.setTitle("다음", for: .normal)
+        $0.titleLabel?.font = UIFont.title1_b
+        $0.setTitleColor(UIColor.white, for: .normal)
+        $0.backgroundColor = UIColor.primary900
+    }
+    
+    private let paddingView = UIView().then {
+        $0.backgroundColor = UIColor.primary900
+    }
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        onboardingCollectionView.configure(items)
+        onboardingPageControl.numberOfPages = items.count
+        bind()
+        setAddTarget()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if onboardingCollectionView.isHidden {
+            onboardingCollectionView.collectionViewLayout = UICollectionViewFlowLayout().then {
+                $0.itemSize = CGSize(width: view.frame.width, height: view.safeAreaLayoutGuide.layoutFrame.height - 88 - 56)
+                $0.minimumLineSpacing = 0
+                $0.scrollDirection = .horizontal
+            }
+            onboardingCollectionView.isHidden = false
+        }
+    }
+    
+    // MARK: - Base
+    override func addSubview() {
+        [onboardingPageControl, onboardingCollectionView, nextButton, paddingView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setLayout() {
+        onboardingPageControl.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(54)
+            $0.height.equalTo(8)
+        }
+        
+        onboardingCollectionView.snp.makeConstraints {
+            $0.top.equalTo(onboardingPageControl.snp.bottom).offset(16)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.height.equalTo(56)
+            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        paddingView.snp.makeConstraints {
+            $0.top.equalTo(nextButton.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+extension OnboardingViewController {
+    
+    func bind() {
+        onboardingCollectionView.pageChangedPublisher.sink { [weak self] page in
+            self?.onboardingPageControl.currentPage = page
+        }.store(in: &subscriptions)
+        
+        onboardingPageControl.lastPagePublisher.sink { [weak self] isLast in
+            self?.nextButton.setTitle(isLast ? "시작하기" : "다음", for: .normal)
+        }.store(in: &subscriptions)
+    }
+    
+    func setAddTarget() {
+        nextButton.addTarget(self, action: #selector(nextButtonTapped(_:)), for: .touchUpInside)
+    }
+    
+    @objc private func nextButtonTapped(_ sender: UIButton) {
+        
+        if onboardingPageControl.currentPage == onboardingPageControl.numberOfPages - 1 {
+            delegate?.startButtonTapped()
+            return
+        }
+        
+        let indexPath = IndexPath(item: onboardingPageControl.currentPage + 1, section: 0)
+        onboardingCollectionView.scrollToItem(
+            at: indexPath,
+            at: .centeredHorizontally,
+            animated: true
+        )
+    }
+}


### PR DESCRIPTION
빈 화면을 탭했을 때 키보드를 내려주는 메서드를 추가했습니다.

- #29 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

UIViewController extension을 추가하고, dismissKeyboardWhenTapAround 메서드를 구현했습니다.
UIGestureRecognizer를 이용하여 화면의 빈 공간을 탭했을 때 키보드를 닫아주는 메서드입니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Users can now dismiss the keyboard by tapping outside input fields, improving text-input usability.
  * A multi-step onboarding flow has been added, featuring paged introduction screens, progress indicators, and a start action to guide new users through initial setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->