### PR TITLE
setting: 토스트 메시지

### DIFF
--- a/dnd-14th-1-iOS/Global/Extension/UIViewController+.swift
+++ b/dnd-14th-1-iOS/Global/Extension/UIViewController+.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import Then
+import SnapKit
 
 extension UIViewController {
     
@@ -17,5 +19,93 @@ extension UIViewController {
     
     @objc func dismissKeyboard() {
         view.endEditing(true)
+    }
+}
+
+extension UIViewController {
+    
+    enum ToastType {
+        case internalError
+        case networkError
+    }
+    
+    func showToast(message: String, type: ToastType) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+            return
+        }
+        
+        let toastImageView: UIImageView?
+        let toastView = UIView().then {
+            $0.layer.cornerRadius = 14
+            $0.clipsToBounds = true
+            $0.alpha = 0
+            $0.tag = 999
+        }
+        let toastLabel = UILabel().then {
+            $0.font = UIFont.label2_b
+            $0.text = message
+            $0.textColor = .white
+        }
+        switch type {
+        case .internalError:
+            toastImageView = UIImageView(image: UIImage(systemName: "exclamationmark.circle"))
+            toastImageView?.tintColor = .white
+            toastView.backgroundColor = UIColor(hexCode: "FF4242")
+        case .networkError:
+            toastImageView = nil
+            toastView.backgroundColor = UIColor(hexCode: "A1A1A1")
+        }
+        
+        if let toastImageView {
+            [toastImageView, toastLabel].forEach {
+                toastView.addSubview($0)
+            }
+            toastImageView.snp.makeConstraints {
+                $0.size.equalTo(20)
+                $0.top.equalTo(toastView).offset(4)
+                $0.leading.equalTo(toastView).offset(8)
+            }
+            toastLabel.snp.makeConstraints {
+                $0.centerY.equalTo(toastView)
+                $0.leading.equalTo(toastImageView.snp.trailing).offset(4)
+                $0.trailing.equalTo(toastView).offset(-8)
+            }
+        } else {
+            [toastLabel].forEach {
+                toastView.addSubview($0)
+            }
+            toastLabel.snp.makeConstraints {
+                $0.centerY.equalTo(toastView)
+                $0.leading.trailing.equalTo(toastView).inset(12)
+            }
+        }
+        
+        window.viewWithTag(999)?.removeFromSuperview()
+        window.addSubview(toastView)
+        toastView.snp.makeConstraints {
+            $0.height.equalTo(28)
+            $0.bottom.equalTo(window.safeAreaLayoutGuide).offset(-24)
+            $0.centerX.equalTo(window)
+        }
+        
+        UIView.animate(
+            withDuration: 0.25,
+            animations: {
+                toastView.alpha = 1
+            },
+            completion: { _ in
+                UIView.animate(
+                    withDuration: 0.25,
+                    delay: 3.0,
+                    animations: {
+                        toastView.alpha = 0
+                    },
+                    completion: { _ in
+                        toastView.removeFromSuperview()
+                    }
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #34 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

토스트메시지입니다.
정확한 레이아웃과 애니메이션이 정해져있지않아서, 하단 safeArea보다 24만큼 위에 3초동안 보이도록 했습니다.
~네트워크 오류일 때 그라데이션 일단 생략했습니다.. 이후에 추가해볼게요!~

### 스크린샷 (선택)

![ezgif-52951e8ac7904378](https://github.com/user-attachments/assets/acbe7386-fe3e-47bd-9603-4c4929c37a00)
![ezgif-5d7a0c7067a48bf8](https://github.com/user-attachments/assets/8450f6ce-fb20-4b5a-9f5d-0e4bbd9c1dc9)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toast notifications for displaying error messages throughout the app with smooth fade-in and fade-out animations.
  * Toast notifications support internal error and network error message types with automatic dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->