### PR TITLE
fix: kingfisher setImage 헤더에 토큰 주입

### DIFF
--- a/dnd-14th-1-iOS/Global/Extension/UIImageView+.swift
+++ b/dnd-14th-1-iOS/Global/Extension/UIImageView+.swift
@@ -16,22 +16,25 @@ extension UIImageView {
         case bothMemoryAndDisk
     }
     
-    func setImage(url: String, _ cacheOption: CacheOption = .bothMemoryAndDisk) {
+    func setImage(url: String) {
         
         guard let url = URL(string: url) else {
             return
         }
         
-        var options: KingfisherOptionsInfo = [.transition(.fade(0.2))]
-        
-        switch cacheOption {
-        case .none:
-            break
-        case .memoryOnly:
-            options.append(.cacheMemoryOnly)
-        case .bothMemoryAndDisk:
-            options.append(.cacheOriginalImage)
+        let accessToken = KeychainWorker.shared.read(key: .access) ?? ""
+        let modifier = AnyModifier { request in
+            var modifiedRequest = request
+            modifiedRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            return modifiedRequest
         }
+        
+        let options: KingfisherOptionsInfo = [
+            .requestModifier(modifier),
+            .transition(.fade(0.2)),
+            .forceTransition,
+            .cacheOriginalImage
+        ]
         
         self.kf.setImage(with: url, options: options)
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #61 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

imageUrl 로딩시 401 오류 방지를 위해 access 토큰을 헤더에 추가합니다.
애니메이션 없이 이미지가 로드되는 문제를 수정합니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading to properly handle authenticated requests, ensuring images requiring authorization now display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->