### PR TITLE
feat: 카카오톡 공유 기능 구현

### DIFF
--- a/dnd-14th-1-iOS.xcodeproj/project.pbxproj
+++ b/dnd-14th-1-iOS.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		7C9582A92F3562D0004F8523 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582A82F3562D0004F8523 /* LoginViewController.swift */; };
 		7C9582AE2F356608004F8523 /* CheckLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582AD2F356608004F8523 /* CheckLoginUseCase.swift */; };
 		7CA03F032F51E64F0086CACB /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 7CA03F022F51E64F0086CACB /* KakaoSDK */; };
+		7CA041232F51FB440086CACB /* UploadImageToKakaoServerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA041222F51FB440086CACB /* UploadImageToKakaoServerUseCase.swift */; };
 		7CCB1E3C2F29B09C00472669 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 7CCB1E3B2F29B09C00472669 /* Alamofire */; };
 		7CCB1E412F29B5ED00472669 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCB1E402F29B5ED00472669 /* Router.swift */; };
 		7CCB1E5D2F2DB19600472669 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 7CCB1E5C2F2DB19600472669 /* Then */; };
@@ -220,6 +221,7 @@
 		7C9582A32F3561DC004F8523 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		7C9582A82F3562D0004F8523 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7C9582AD2F356608004F8523 /* CheckLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginUseCase.swift; sourceTree = "<group>"; };
+		7CA041222F51FB440086CACB /* UploadImageToKakaoServerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageToKakaoServerUseCase.swift; sourceTree = "<group>"; };
 		7CCB1E402F29B5ED00472669 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		7CCB1E712F2DD20300472669 /* KeychainWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainWorker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -485,6 +487,7 @@
 			isa = PBXGroup;
 			children = (
 				7C3A7ABA2F513DE500E25089 /* FetchEcoTierUseCase.swift */,
+				7CA041222F51FB440086CACB /* UploadImageToKakaoServerUseCase.swift */,
 			);
 			path = Eco;
 			sourceTree = "<group>";
@@ -925,6 +928,7 @@
 				7C9016812F502C5300933379 /* BottomSheetPresenter.swift in Sources */,
 				0027D9E32F4054B5000DE576 /* AppCoordinator.swift in Sources */,
 				7C01074D2F45FE3F0005AC1D /* TermsOfUseViewController.swift in Sources */,
+				7CA041232F51FB440086CACB /* UploadImageToKakaoServerUseCase.swift in Sources */,
 				7C90189B2F50685900933379 /* MyBadgesCollectionViewCell.swift in Sources */,
 				7C90189C2F50685900933379 /* MyBadgesCollectionView.swift in Sources */,
 				7CCB1E412F29B5ED00472669 /* Router.swift in Sources */,

--- a/dnd-14th-1-iOS.xcodeproj/project.pbxproj
+++ b/dnd-14th-1-iOS.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		7C9582A42F3561DC004F8523 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582A32F3561DC004F8523 /* OnboardingViewController.swift */; };
 		7C9582A92F3562D0004F8523 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582A82F3562D0004F8523 /* LoginViewController.swift */; };
 		7C9582AE2F356608004F8523 /* CheckLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9582AD2F356608004F8523 /* CheckLoginUseCase.swift */; };
+		7CA03F032F51E64F0086CACB /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 7CA03F022F51E64F0086CACB /* KakaoSDK */; };
 		7CCB1E3C2F29B09C00472669 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 7CCB1E3B2F29B09C00472669 /* Alamofire */; };
 		7CCB1E412F29B5ED00472669 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCB1E402F29B5ED00472669 /* Router.swift */; };
 		7CCB1E5D2F2DB19600472669 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 7CCB1E5C2F2DB19600472669 /* Then */; };
@@ -276,6 +277,7 @@
 				7CCB1E602F2DB2C900472669 /* SnapKit in Frameworks */,
 				7CCB1E3C2F29B09C00472669 /* Alamofire in Frameworks */,
 				7CCB1E5D2F2DB19600472669 /* Then in Frameworks */,
+				7CA03F032F51E64F0086CACB /* KakaoSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -828,6 +830,7 @@
 				7CCB1E5F2F2DB2C900472669 /* SnapKit */,
 				7C0107362F43A92B0005AC1D /* Kingfisher */,
 				0036FDC82F4DB83A00200357 /* Lottie */,
+				7CA03F022F51E64F0086CACB /* KakaoSDK */,
 			);
 			productName = "dnd-14th-1-iOS";
 			productReference = 7C61D2C72F2109B3005FAC3A /* dnd-14th-1-iOS.app */;
@@ -863,6 +866,7 @@
 				7CCB1E5E2F2DB2C900472669 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				7C0107352F43A92B0005AC1D /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				0036FDC72F4DB83A00200357 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				7CA03F012F51E64F0086CACB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 7C61D2C82F2109B3005FAC3A /* Products */;
@@ -1234,6 +1238,14 @@
 				minimumVersion = 8.6.2;
 			};
 		};
+		7CA03F012F51E64F0086CACB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		7CCB1E3A2F29B09C00472669 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire";
@@ -1270,6 +1282,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7C0107352F43A92B0005AC1D /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		7CA03F022F51E64F0086CACB /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7CA03F012F51E64F0086CACB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
 		};
 		7CCB1E3B2F29B09C00472669 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/dnd-14th-1-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dnd-14th-1-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0921f4b62ef003e3a0d8a560f11bf70eae2319767bdc5b1eedd26bb6e9e62553",
+  "originHash" : "7db0b73b620de9a4258465b8b7d3135303f0504b212d6bd522de12301b1bbe0c",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/dnd-14th-1-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dnd-14th-1-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "33467af61e0ed229f00d2cad0313a49316d568a9f1489f5496b7bdacc8b8cc01",
+  "originHash" : "0921f4b62ef003e3a0d8a560f11bf70eae2319767bdc5b1eedd26bb6e9e62553",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5978979157a5a0521c9c56fd0156aec794caa21c"
       }
     },
     {

--- a/dnd-14th-1-iOS/AppConfig.swift
+++ b/dnd-14th-1-iOS/AppConfig.swift
@@ -21,4 +21,11 @@ struct AppConfig {
         }
         return apiKey
     }()
+    
+    static let kakaoAppKey: String = {
+        guard let apiKey = Bundle.main.infoDictionary?["KAKAO_APP_KEY"] as? String, !apiKey.isEmpty else {
+            fatalError("KAKAO_APP_KEY must be set in the Info.plist and cannot be empty.")
+        }
+        return apiKey
+    }()
 }

--- a/dnd-14th-1-iOS/Apps/AppDelegate.swift
+++ b/dnd-14th-1-iOS/Apps/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import KakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -13,7 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        
+        KakaoSDK.initSDK(appKey: AppConfig.kakaoAppKey)
         return true
     }
 

--- a/dnd-14th-1-iOS/Domain/UseCase/Eco/UploadImageToKakaoServerUseCase.swift
+++ b/dnd-14th-1-iOS/Domain/UseCase/Eco/UploadImageToKakaoServerUseCase.swift
@@ -1,0 +1,89 @@
+//
+//  UpdateImageToKakaoServerUseCase.swift
+//  dnd-14th-1-iOS
+//
+//  Created by 홍기정 on 2/28/26.
+//
+
+import UIKit
+import Combine
+import KakaoSDKShare
+
+
+enum KakaoTemplate: Int64 {
+    case tier = 130045
+    case badge = 130046
+}
+
+protocol KakaoShareUseCase {
+    func execute(image: UIImage, template: KakaoTemplate) -> AnyPublisher<Bool, ErrorResponse>
+}
+
+final class DefaultKakaoShareUseCase: KakaoShareUseCase {
+    
+    func execute(image: UIImage, template: KakaoTemplate) -> AnyPublisher<Bool, ErrorResponse> {
+
+        return uploadImageToKakaoServer(image: image)
+            .flatMap { [weak self] imageUrl -> AnyPublisher<Void, ErrorResponse> in
+                guard let self else {
+                    return Fail(error: ErrorResponse(customStatusCode: 0, data: nil, message: "weak self is nil", status: 0))
+                        .eraseToAnyPublisher()
+                }
+                return self.launchKakaoAndShare(imageUrl: imageUrl, template: template)
+            }
+            .map { _ in
+                return true
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+extension DefaultKakaoShareUseCase {
+    
+    private func uploadImageToKakaoServer(image: UIImage) -> AnyPublisher<String, ErrorResponse> {
+        return Future { promise in
+            //해당 이미지를 카카오 공유 서버에 업로드
+            ShareApi.shared.imageUpload(image: image) { (imageUploadResult, error ) in
+                if let error = error { //업로드 실패
+                    print(error)
+                    let errorResponse = ErrorResponse(customStatusCode: 0, data: nil, message: "카카오서버에 이미지 업로드 실패", status: 0)
+                    promise(.failure(errorResponse))
+                } else if let url = imageUploadResult?.infos.original.url { //업로드 성공
+                    print("imageUpload() success.")
+                    promise(.success(url.absoluteString))
+                } else {
+                    let errorResponse = ErrorResponse(customStatusCode: 0, data: nil, message: "카카오서버에서 URL 생성 실패", status: 0)
+                    promise(.failure(errorResponse))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    private func launchKakaoAndShare(imageUrl: String, template: KakaoTemplate) -> AnyPublisher<Void, ErrorResponse> {
+        return Future { promise in
+            KakaoSDKShare.ShareApi.shared.shareCustom(
+                templateId: template.rawValue,
+                templateArgs: ["THU" : imageUrl],
+                completion: { (result, error) in
+                    if let result {
+                        DispatchQueue.main.async {
+                            UIApplication.shared.open(result.url) { success in
+                                if success {
+                                    promise(.success(()))
+                                } else {
+                                    let errorResponse = ErrorResponse(customStatusCode: 0, data: nil, message: "카카오톡 실행 실패", status: 0)
+                                    promise(.failure(errorResponse))
+                                }
+                            }
+                        }
+                    } else {
+                        let errorResponse = ErrorResponse(customStatusCode: 0, data: nil, message: "카카오톡 공유 실패", status: 0)
+                        promise(.failure(errorResponse))
+                    }
+                }
+            )
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/dnd-14th-1-iOS/Info.plist
+++ b/dnd-14th-1-iOS/Info.plist
@@ -4,8 +4,25 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao${KAKAO_APP_KEY}</string>
+			</array>
+		</dict>
+	</array>
 	<key>CLAUDE_API_KEY</key>
 	<string>$(CLAUDE_API_KEY)</string>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_APP_KEY)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaolink</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/dnd-14th-1-iOS/Presentation/Eco/MyEcoCoordinator.swift
+++ b/dnd-14th-1-iOS/Presentation/Eco/MyEcoCoordinator.swift
@@ -34,14 +34,22 @@ final class MyEcoCoordinator: Coordinator {
 extension MyEcoCoordinator: EcoViewControllerDelegate {
     
     func presentShareTier(tier: EcoTier) {
-        let shareTierModalViewController = ShareTierModalViewController(tier: tier)
+        let kakaoShareUseCase = DefaultKakaoShareUseCase()
+        let shareTierModalViewController = ShareTierModalViewController(
+            tier: tier,
+            kakaoShareUseCase: kakaoShareUseCase
+        )
         shareTierModalViewController.modalPresentationStyle = .overFullScreen
         shareTierModalViewController.modalTransitionStyle = .crossDissolve
         navigationController.present(shareTierModalViewController, animated: true)
     }
     
     func presentShareBadge(badge: Badge) {
-        let shareBadgeModalViewController = ShareBadgeModalViewController(badge: badge)
+        let kakaoShareUseCase = DefaultKakaoShareUseCase()
+        let shareBadgeModalViewController = ShareBadgeModalViewController(
+            badge: badge,
+            kakaoShareUseCase: kakaoShareUseCase
+        )
         shareBadgeModalViewController.modalPresentationStyle = .overFullScreen
         shareBadgeModalViewController.modalTransitionStyle = .crossDissolve
         navigationController.present(shareBadgeModalViewController, animated: true)

--- a/dnd-14th-1-iOS/Presentation/Eco/ShareBadge/ShareBadgeModalViewController.swift
+++ b/dnd-14th-1-iOS/Presentation/Eco/ShareBadge/ShareBadgeModalViewController.swift
@@ -13,23 +13,32 @@ import Then
 final class ShareBadgeModalViewController: BaseViewController {
     
     // MARK: - Properties
+    private let kakaoShareUseCase: KakaoShareUseCase
+    private var subscriptions: Set<AnyCancellable> = []
     private let badge: Badge
     private var didLayoutSubviews = false
+    
     
     // MARK: - UI Components
     private let blurredBackgroundView = CustomVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterialDark), intensity: 0.2)
     private let contentView = UIView()
     private let closeButton = UIButton()
+    private let shareButton = AppButton(size: .large, title: "SNS 공유", image: UIImage.shareNetwork)
+    
+    private let wrapperView = UIView()
     private let myBadgeLabel = UILabel()
     private let dateLabel = UILabel()
     private let badgeImageView = UIImageView()
     private let badgeTitleLabel = UILabel()
     private let badgeDescriptionLabel = UILabel()
-    private let shareButton = AppButton(size: .large, title: "SNS 공유", image: UIImage.shareNetwork)
     
     // MARK: - Initializer
-    init(badge: Badge) {
+    init(
+        badge: Badge,
+        kakaoShareUseCase: KakaoShareUseCase
+    ) {
         self.badge = badge
+        self.kakaoShareUseCase = kakaoShareUseCase
         super.init()
     }
     required init?(coder: NSCoder) {
@@ -53,7 +62,10 @@ final class ShareBadgeModalViewController: BaseViewController {
     // MARK: - Base
     
     override func addSubview() {
-        [closeButton, myBadgeLabel, dateLabel, badgeImageView, badgeTitleLabel, badgeDescriptionLabel, shareButton].forEach {
+        [myBadgeLabel, dateLabel, badgeImageView, badgeTitleLabel, badgeDescriptionLabel].forEach {
+            wrapperView.addSubview($0)
+        }
+        [wrapperView, closeButton, shareButton].forEach {
             contentView.addSubview($0)
         }
         [blurredBackgroundView, contentView].forEach {
@@ -75,32 +87,39 @@ final class ShareBadgeModalViewController: BaseViewController {
             $0.size.equalTo(24)
             $0.top.trailing.equalTo(contentView).inset(28)
         }
+        
+        wrapperView.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(contentView)
+        }
+        
         myBadgeLabel.snp.makeConstraints {
             $0.height.equalTo(20)
-            $0.top.equalTo(contentView).offset(40)
-            $0.centerX.equalTo(contentView)
+            $0.top.equalTo(wrapperView).offset(40)
+            $0.centerX.equalTo(wrapperView)
         }
         dateLabel.snp.makeConstraints {
             $0.height.equalTo(21)
             $0.top.equalTo(myBadgeLabel.snp.bottom).offset(8)
-            $0.centerX.equalTo(contentView)
+            $0.centerX.equalTo(wrapperView)
         }
         badgeImageView.snp.makeConstraints {
             $0.top.equalTo(dateLabel.snp.bottom).offset(22.5)
             $0.height.equalTo(195)
-            $0.centerX.equalTo(contentView)
+            $0.centerX.equalTo(wrapperView)
         }
         badgeTitleLabel.snp.makeConstraints {
             $0.height.equalTo(42)
             $0.top.equalTo(badgeImageView.snp.bottom).offset(8)
-            $0.centerX.equalTo(contentView)
+            $0.centerX.equalTo(wrapperView)
         }
         badgeDescriptionLabel.snp.makeConstraints {
             $0.top.equalTo(badgeTitleLabel.snp.bottom) // .offset(8)
-            $0.centerX.equalTo(contentView)
+            $0.centerX.equalTo(wrapperView)
+            $0.bottom.equalTo(wrapperView).offset(-15.5 - 10)
         }
+        
         shareButton.snp.makeConstraints {
-            $0.top.equalTo(badgeDescriptionLabel.snp.bottom).offset(15.5)
+            $0.top.equalTo(wrapperView.snp.bottom).offset(-10)
             $0.leading.trailing.equalTo(contentView).inset(24)
             $0.bottom.equalTo(contentView).offset(-36)
         }
@@ -159,7 +178,7 @@ extension ShareBadgeModalViewController {
         ]
         gradientLayer.startPoint = CGPoint(x: 0, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0, y: 1)
-        contentView.layer.insertSublayer(gradientLayer, at: 0)
+        wrapperView.layer.insertSublayer(gradientLayer, at: 0)
     }
 }
 
@@ -173,7 +192,16 @@ extension ShareBadgeModalViewController {
     @objc private func closeButtonTapped() {
         dismiss(animated: true)
     }
-    @objc private func shareButtonTapped() {}
+    @objc private func shareButtonTapped() {
+        kakaoShareUseCase.execute(image: wrapperView.asImage(), template: .badge).receive(on: DispatchQueue.main).sink(
+            receiveCompletion: { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.showToast(message: error.message, type: .internalError)
+                }
+            },
+            receiveValue: { _ in }
+        ).store(in: &subscriptions)
+    }
 }
 
 extension ShareBadgeModalViewController {

--- a/dnd-14th-1-iOS/Presentation/Eco/ShareTier/ShareTierModalViewController.swift
+++ b/dnd-14th-1-iOS/Presentation/Eco/ShareTier/ShareTierModalViewController.swift
@@ -14,7 +14,9 @@ import Photos
 final class ShareTierModalViewController: BaseViewController {
     
     // MARK: - Properties
+    private let kakaoShareUseCase: KakaoShareUseCase
     private let tier: EcoTier
+    private var subscriptions: Set<AnyCancellable> = []
     
     // MARK: - UI Components
     private let blurredBackgroundView = CustomVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterialDark), intensity: 0.2)
@@ -30,8 +32,12 @@ final class ShareTierModalViewController: BaseViewController {
     private let imageDownloadButton = UIButton()
     
     // MARK: - Initializer
-    init(tier: EcoTier) {
+    init(
+        tier: EcoTier,
+        kakaoShareUseCase: KakaoShareUseCase
+    ) {
         self.tier = tier
+        self.kakaoShareUseCase = kakaoShareUseCase
         super.init()
     }
     required init?(coder: NSCoder) {
@@ -49,7 +55,7 @@ final class ShareTierModalViewController: BaseViewController {
         [titleLabel, tierLabel, glacierImageView, descriptionLabel].forEach {
             wrapperView.addSubview($0)
         }
-        [closeButton, wrapperView, kakaoShareButton, imageDownloadButton].forEach {
+        [wrapperView, kakaoShareButton, imageDownloadButton, closeButton].forEach {
             contentView.addSubview($0)
         }
         [blurredBackgroundView, contentView].forEach {
@@ -93,12 +99,12 @@ final class ShareTierModalViewController: BaseViewController {
             $0.height.equalTo(24)
             $0.top.equalTo(glacierImageView.snp.bottom).offset(40)
             $0.centerX.equalTo(wrapperView)
-            $0.bottom.equalTo(wrapperView).offset(-24)
+            $0.bottom.equalTo(wrapperView).offset(-24 - 10)
         }
         
         kakaoShareButton.snp.makeConstraints {
             $0.height.equalTo(60)
-            $0.top.equalTo(wrapperView.snp.bottom)
+            $0.top.equalTo(wrapperView.snp.bottom).offset(-10)
             $0.leading.equalTo(contentView).offset(16)
             $0.trailing.equalTo(imageDownloadButton.snp.leading).offset(-8)
             $0.bottom.equalTo(contentView).offset(-32)
@@ -174,22 +180,38 @@ final class ShareTierModalViewController: BaseViewController {
             $0.layer.cornerRadius = 30
             $0.clipsToBounds = true
         }
+        
+        wrapperView.do {
+            $0.backgroundColor = UIColor(hexCode: "FAFAFA")
+        }
     }
 }
 
 extension ShareTierModalViewController {
     
     private func setAddTarget() {
-        
         closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
         kakaoShareButton.addTarget(self, action: #selector(kakaoShareButtonTapped), for: .touchUpInside)
         imageDownloadButton.addTarget(self, action: #selector(imageDownloadButtonTapped), for: .touchUpInside)
     }
     
     @objc private func closeButtonTapped() {
-        dismiss(animated: true)
+        presentingViewController?.dismiss(animated: true)
     }
-    @objc private func kakaoShareButtonTapped() {}
+}
+
+extension ShareTierModalViewController {
+
+    @objc private func kakaoShareButtonTapped() {
+        kakaoShareUseCase.execute(image: wrapperView.asImage(), template: .tier).receive(on: DispatchQueue.main).sink(
+            receiveCompletion: { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.showToast(message: error.message, type: .internalError)
+                }
+            },
+            receiveValue: { _ in }
+        ).store(in: &subscriptions)
+    }
 }
 
 extension ShareTierModalViewController {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #57

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

카카오톡 공유 기능 구현 작업입니다.

플로우는 다음과 같습니다.
1. 공유할 영역을 UIImage 로 변환
2. 카카오톡 서버에 업로드하여 imageUrl 획득
3. imageUrl 을 포함하여 카카오톡 공유

Kakao Developers 에서 티어 공유, 배지 공유 템플릿을 만들었습니다.
사진 비율에 차이가 있습니다.

saving이 설치되어있을 경우 앱으로 이동하고 (scheme)
설치되어있지 않을 경우 dnd 페이지로 이동합니다.
(testflight 주소로 이동하도록 구현하려했으나 불가능)

### 스크린샷 (선택)

![IMG_1947](https://github.com/user-attachments/assets/69cfbf75-2f99-4827-bae0-7eac340d4d4e)
![IMG_1948](https://github.com/user-attachments/assets/d934b253-9861-4dbf-9071-06cb249ad512)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kakao Talk integration for sharing badges and tiers. Users can now share their achievements with others directly through Kakao Talk messaging from the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->